### PR TITLE
fix: missing imports / circular reference in the Adhesive class

### DIFF
--- a/example-sketchboard-init.js
+++ b/example-sketchboard-init.js
@@ -1,7 +1,9 @@
 import * as d3 from "d3";
-import Gallery from './lib/gallery';
-import SketchBoard from './lib/sketchboard';
-import Stack from './lib/stack';
+import {
+    Gallery,
+    SketchBoard,
+    Stack
+} from './lib';
 
 // the gallery controls the available images
 var gallery = new Gallery(["example-images/lfs-logo.png",

--- a/lib/adhesive.js
+++ b/lib/adhesive.js
@@ -345,12 +345,19 @@ class Adhesive {
         var nY = this.group.node().getBoundingClientRect().top -
                     this.parentGroup.node().getBoundingClientRect().top +
                     this.position[1];
-        h.on("click", function() {
-            let n = new URI(p.board, g, p, "",
-                        ["#ddddff"], undefined, [nX, nY]);
-            n.setFeatures(["close","label","edit"], p.draggable, true, false, "URI Name;scheme:path");
-            p.childObjects.set(n.id, n);
 
+        h.on("click", function() {
+	    let n = p.board.createNewURI(
+		p.board, g, p, "", ["#ddddff"], undefined, [nX, nY]
+	    )
+	    n.setFeatures(
+		["close","label","edit"],
+		p.draggable,
+		true,
+		false,
+		"URI Name;scheme:path"
+	    );
+            p.childObjects.set(n.id, n);
             p.board.adhesives.set(n.id, n);
             g.raise();
         });
@@ -372,7 +379,7 @@ class Adhesive {
                     this.parentGroup.node().getBoundingClientRect().top +
                     this.position[1];
         h.on("click", function() {
-            let n = new InstantPhoto(p.board, g, p, "");
+            let n = p.board.createNewInstantPhoto(p.board, g, p, "");
             n.setFeatures(["close", "label", "edit"],
                                 p.draggable, true, false, "Photo");
             p.childObjects.set(n.id, n);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,17 @@
+import Gallery from './gallery';
+import SketchBoard from './sketchboard';
+import Stack from './stack';
+
+
+/**
+ * Public API for note-it
+ * exports a set of object to choose from for different projects
+ * you can find an example init in
+ * note-it/example-sketchboard-init.js
+ **/
+
+export {
+    Gallery,
+    SketchBoard,
+    Stack
+};

--- a/lib/sketchboard.js
+++ b/lib/sketchboard.js
@@ -191,6 +191,22 @@ class SketchBoard {
             alert("There is no '" + adhesiveKey + "' in the adhesiveQueue");
         }
     }
+
+    /**
+     * Create a totally new URI Adhesive
+     * parameters are identic to the one of the URI class
+     **/
+    createNewURI(board, group, parentObject, id, color, geometry, position) {
+	return new URI(board, group, parentObject, id, color, geometry, position);
+    }
+
+    /**
+     * Create a totally new InstantPhoto Adhesive
+     * parameters are identic to the one of the InstantPhoto class
+     **/
+    createNewInstantPhoto(board, group, parentObject, id, color, geometry, position) {
+	return new URI(board, group, parentObject, id, color, geometry, position);
+    }
 }
 
 export default SketchBoard;


### PR DESCRIPTION
During #33 I missed some imports leading to part of the app not working (new `URI` and new `InstantPhoto`).

Fixing the imports in `./lib/adhesive.js` is leading to a new error that I'm currently trying to solve.

It seems to be because of the files crossed referenced, used in:
- https://github.com/inofix/note-it-js/blob/master/lib/adhesive.js#L349
- https://github.com/inofix/note-it-js/blob/master/lib/adhesive.js#L375

These two classes, are extending the one defined in the file they are called in.
And the parent classes creates new instances of its children's.

Note: one quick way of solving this issue would be to merge these three files in one, getting rid of the imports, but that would defeat the purpose of the original PR (#33).
