### PR TITLE
fix InstantPhoto

### DIFF
--- a/lib/sketchboard.js
+++ b/lib/sketchboard.js
@@ -205,7 +205,7 @@ class SketchBoard {
      * parameters are identic to the one of the InstantPhoto class
      **/
     createNewInstantPhoto(board, group, parentObject, id, color, geometry, position) {
-	return new URI(board, group, parentObject, id, color, geometry, position);
+	return new InstantPhoto(board, group, parentObject, id, color, geometry, position);
     }
 }
 


### PR DESCRIPTION
While #34 I made a mistake and instead of creating a `new InstantPhoto`, it was creating a `new URI`.

This PR fixes that,
closes #41 