### PR TITLE
Feat/general ux

### DIFF
--- a/example-sketchboard-init.js
+++ b/example-sketchboard-init.js
@@ -1,62 +1,75 @@
 import * as d3 from 'd3'
 import { Gallery, SketchBoard, Stack } from './lib'
 
-// the gallery controls the available images
-var gallery = new Gallery(
-  ['example-images/lfs-logo.png', 'example-images/meditate-tiny.jpg'],
-  false
-)
+// self invoking function to keep the window js scope clean
+;(function() {
+  // the gallery controls the available images
+  var gallery = new Gallery(
+    ['example-images/lfs-logo.png', 'example-images/meditate-tiny.jpg'],
+    false
+  )
 
-gallery.displayImageList('#sketchboardimages')
+  gallery.displayImageList('#sketchboardimages')
 
-// the board is the main container to organize the adhesives on
-var board = new SketchBoard(
-  '#sketchboard',
-  undefined,
-  undefined,
-  false,
-  gallery
-)
+  // the board is the main container to organize the adhesives on
+  var board = new SketchBoard(
+    '#sketchboard',
+    undefined,
+    undefined,
+    false,
+    gallery
+  )
 
-// a stack is an entry point containing an adhesive to creating the
-// rest of the elements from..
-var rstack = new Stack(
-  board,
-  board.group,
-  'Type',
-  ['#f7ff72', '#ff72e3', '#6ee0ff', '#ffa800', '#a9a9ff', '#b3ff7b'],
-  [14, 14]
-)
+  // a stack is an entry point containing an adhesive to creating the
+  // rest of the elements from..
+  var rstack = new Stack(
+    board,
+    board.group,
+    'Type',
+    ['#f7ff72', '#ff72e3', '#6ee0ff', '#ffa800', '#a9a9ff', '#b3ff7b'],
+    [14, 14]
+  )
 
-// the back(-end) is where the JSON representation goes - it can be
-// used to later restore the board
-var back = d3.select('#sketchboardjson')
-let a = back
-  .append('textarea')
-  .attr('rows', 10)
-  .attr('cols', 80)
-a.on('keyup', function() {
-  let t = d3.select('#sketchboardjson').select('textarea')
-  t.attr('value', t.node().textContent)
-})
-back
-  .append('input')
-  .attr('type', 'button')
-  .attr('value', 'To JSON')
-  .on('click', function() {
+  // the back(-end) is where the JSON representation goes - it can be
+  // used to later restore the board
+  var back = d3.select('#sketchboardjson')
+  let a = back
+    .append('textarea')
+    .attr('rows', 10)
+    .attr('cols', 80)
+  a.on('keyup', function() {
     let t = d3.select('#sketchboardjson').select('textarea')
-    t.text(board.toJSON('  '))
-    t.property('value', t.node().textContent)
+    t.attr('value', t.node().textContent)
   })
-back
-  .append('input')
-  .attr('type', 'button')
-  .attr('value', 'From JSON')
-  .on('click', function() {
-    board.fromJSON(
-      d3
-        .select('#sketchboardjson')
-        .select('textarea')
-        .node().value
-    )
+  back
+    .append('input')
+    .attr('type', 'button')
+    .attr('value', 'To JSON')
+    .on('click', function() {
+      let t = d3.select('#sketchboardjson').select('textarea')
+      t.text(board.toJSON('  '))
+      t.property('value', t.node().textContent)
+    })
+  back
+    .append('input')
+    .attr('type', 'button')
+    .attr('value', 'From JSON')
+    .on('click', function() {
+      board.fromJSON(
+        d3
+          .select('#sketchboardjson')
+          .select('textarea')
+          .node().value
+      )
+    })
+
+  // the general interface and navigation
+  var navIsActiveClass = 'Site--navActive'
+  var $nav = document.querySelector('.Site-navigation')
+  var $body = document.querySelector('body')
+  $nav.addEventListener('click', function() {
+    $body.classList.contains(navIsActiveClass)
+      ? $body.classList.remove(navIsActiveClass)
+      : $body.classList.add(navIsActiveClass)
   })
+})()

--- a/example-sketchboard.html
+++ b/example-sketchboard.html
@@ -1,58 +1,105 @@
 <!DOCTYPE html>
 <html lang="en-US">
-  <head>
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
-    <meta content="utf-8" http-equiv="encoding">
+    <head>
+	<meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+	<meta content="utf-8" http-equiv="encoding">
 
-    <style>
-     body, html {
-	width: 100%;
-	height: 100%;
-	margin: 0;
-	  font-family: Helvetica, sans-serif;
-      }
-      #thesketchboard {
-	border: 1px solid black;
-	top: 2px;
-	left: 2px;
-	width: 4096px;
-	height: 2048px;
-      }
-      svg {
-	position: relative;
-	top: 2em;
-	left: 2em;
-	width: 100%;
-	height: 100%;
-      }
-      svg>#sketchboard {
-	background: linear-gradient(#000000, #0000bb);
-      }
-      #sketchboardjson {
-	position: relative;
-	top: 2px;
-	left: 2px;
-      }
-      .paper {
-	stroke: black;
-	stroke-width: 1px;
-      }
-    .handle {
-	cursor: pointer;
-    }
-    .dragable {
-	cursor: move;
-    }
-    </style>
-  </head>
-  <body>
-    <div>
-	<div id="sketchboardjson"></div>
-	<div id="sketchboardimages"></div>
-	<div id="thesketchboard">
-	    <svg id="sketchboard"></svg>
+	<style>
+	/*
+	   box-sizing model
+	   https://css-tricks.com/box-sizing/
+	 */
+
+	html {
+	    box-sizing: border-box;
+	}
+	*, *:before, *:after {
+	    box-sizing: inherit;
+	}
+
+	/* custom styles */
+	html {
+	    font-family: Helvetica, sans-serif;
+	}
+	body {
+	    margin: 0;
+	}
+
+	.Site--navActive .Site-aside {
+	    display: block;
+	}
+	.Site-aside {
+	    display: none;
+	    position: absolute;
+	    top: 0;
+	    left: 0;
+	    right: 0;
+	    bottom: 0;
+	    z-index: 1;
+	    background-color: khaki;
+	    padding: 1.5rem;
+	    margin: 1.5rem;
+	    opacity: 0.95;
+	}
+
+	.Site-aside textarea {
+	    width: 100%;
+	}
+
+	.Site-navigation {
+	    position: fixed;
+	    z-index: 2;
+	    top: 0;
+	    right: 0;
+	    padding: 1rem;
+	    margin: 1rem;
+	    cursor: pointer;
+	    background-color: cyan;
+	}
+	.Site-navigation:hover {
+	    background-color: forestgreen;
+	}
+
+	#thesketchboard {
+	    width: 100%;
+	    min-height: 100vh;
+	    position: relative;
+	}
+	#sketchboard {
+	    padding: 1rem;
+	    /* width + height + position are required */
+	    width: 100%;
+	    height: 100%;
+	    position: absolute;
+	    top: 0;
+	    left: 0;
+	    right: 0;
+	    bottom: 0;
+	}
+
+	.handle {
+	    cursor: pointer;
+	}
+	.dragable {
+	    cursor: move;
+	}
+	</style>
+    </head>
+    <body class="Site">
+	<div>
+	    <nav class="Site-navigation">
+		Menu
+	    </nav>
+	    <aside class="Site-aside">
+		<h1>Note it!</h1>
+		<p>You can export and import your work to JSON.</p>
+		<div id="sketchboardjson"></div>
+		<div id="sketchboardimages"></div>
+	    </aside>
+	    <div id="thesketchboard" class="Site-sketchboard">
+		<svg id="sketchboard"></svg>
+	    </div>
 	</div>
-    </div>
-  </body>
-  <script src="./example-sketchboard-init.js"></script>
+    </body>
+    <script src="./example-sketchboard-init.js"></script>
 </html>

--- a/example-sketchboard.html
+++ b/example-sketchboard.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en-US">
     <head>
-	<meta content="text/html;charset=utf-8" http-equiv="Content-Type">
-	<meta content="utf-8" http-equiv="encoding">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
 
 	<style>
 	/*
@@ -31,6 +31,7 @@
 	.Site-aside {
 	    display: none;
 	    position: absolute;
+	    overflow-x: scroll;
 	    top: 0;
 	    left: 0;
 	    right: 0;

--- a/example-sketchboard.html
+++ b/example-sketchboard.html
@@ -6,47 +6,53 @@
 
     <style>
      body, html {
-        width: 100%;
-        height: 100%;
-        margin: 0;
-          font-family: Helvetica, sans-serif;
+	width: 100%;
+	height: 100%;
+	margin: 0;
+	  font-family: Helvetica, sans-serif;
       }
       #thesketchboard {
-        border: 1px solid black;
-        top: 2px;
-        left: 2px;
-        width: 4096px;
-        height: 2048px;
+	border: 1px solid black;
+	top: 2px;
+	left: 2px;
+	width: 4096px;
+	height: 2048px;
       }
       svg {
-        position: relative;
-        top: 2em;
-        left: 2em;
-        width: 100%;
-        height: 100%;
+	position: relative;
+	top: 2em;
+	left: 2em;
+	width: 100%;
+	height: 100%;
       }
       svg>#sketchboard {
-        background: linear-gradient(#000000, #0000bb);
+	background: linear-gradient(#000000, #0000bb);
       }
       #sketchboardjson {
-        position: relative;
-        top: 2px;
-        left: 2px;
+	position: relative;
+	top: 2px;
+	left: 2px;
       }
       .paper {
-        stroke: black;
-        stroke-width: 1px;
-      }</style>
+	stroke: black;
+	stroke-width: 1px;
+      }
+    .handle {
+	cursor: pointer;
+    }
+    .dragable {
+	cursor: move;
+    }
+    </style>
   </head>
   <body>
     <div>
-        <div id="sketchboardjson"></div>
-        <div id="sketchboardimages"></div>
-        <div id="thesketchboard">
-            <svg id="sketchboard"></svg>
-        </div>
+	<div id="sketchboardjson"></div>
+	<div id="sketchboardimages"></div>
+	<div id="thesketchboard">
+	    <svg id="sketchboard"></svg>
+	</div>
     </div>
   </body>
   <script src="./example-sketchboard-init.js"></script>
 </html>
-

--- a/lib/adhesive.js
+++ b/lib/adhesive.js
@@ -55,6 +55,7 @@ class Adhesive {
       let gYn = geometry[1] + 0.4
       this.group
         .append('rect')
+        .attr('class', 'adhesiveShadow')
         .attr('fill', '#000000')
         .style('opacity', '0.4')
         .attr('width', gXn + 'em')
@@ -62,6 +63,7 @@ class Adhesive {
     }
     this.paper = this.group
       .append('rect')
+      .attr('class', 'adhesive')
       .attr('width', geometry[0] + 'em')
       .attr('height', geometry[1] + 'em')
     this.geometry = geometry
@@ -352,8 +354,10 @@ class Adhesive {
       .append('g')
       .attr('class', 'handle')
       .attr('id', 'handle' + name)
-      .attr('width', '1em')
-      .attr('height', '1em')
+      .attr('tabindex', 0)
+
+    h.append('title').text(name)
+
     return h
       .append('text')
       .text(text)
@@ -609,6 +613,9 @@ class Adhesive {
       .append('stop')
       .attr('offset', '100%')
       .style('stop-color', c[2])
+
+    h.append('title').text('Color')
+
     h.append('rect')
       .attr('x', l)
       .attr('y', 2)
@@ -648,6 +655,8 @@ class Adhesive {
 
     var nX = this.translatePosition[0]
     var nY = this.translatePosition[1]
+
+    this.group.attr('class', 'dragable')
 
     this.group.call(
       d3.drag().on('drag', function() {

--- a/lib/sketchboard.js
+++ b/lib/sketchboard.js
@@ -41,9 +41,9 @@ class SketchBoard {
     this.group = this.svg.append('g').attr('class', 'sketchboard')
     //TODO add a slider and some shortcuts too for keyboard fetishists like myself (I have no wheel on my trackpoint)..
     var g = this.group
-    this.group.call(
+    this.svg.call(
       d3.zoom().on('zoom', function() {
-        g.attr('transform', 'scale(' + d3.event.transform.k + ')')
+        g.attr('transform', d3.event.transform)
       })
     )
 
@@ -203,8 +203,24 @@ class SketchBoard {
    * Create a totally new InstantPhoto Adhesive
    * parameters are identic to the one of the InstantPhoto class
    **/
-  createNewInstantPhoto(board, group, parentObject, id, color, geometry, position) {
-	  return new InstantPhoto(board, group, parentObject, id, color, geometry, position);
+  createNewInstantPhoto(
+    board,
+    group,
+    parentObject,
+    id,
+    color,
+    geometry,
+    position
+  ) {
+    return new InstantPhoto(
+      board,
+      group,
+      parentObject,
+      id,
+      color,
+      geometry,
+      position
+    )
   }
 }
 


### PR DESCRIPTION
This PR (to merge after #49 ):

- makes the User Interface full-screen (without scroll bars)
- moves the JSON import/export to a hidden-by-default menu
- improves the zoom behavior (zoom anywhere on the page — not only from on the adhesive, and move the sketchboard around to control where it is centered and zoomed)

The idea was to make it as nice as possible de get to explore the interface of the application, by centering the focus on the core functionalities of the app (create and organize visual notes)